### PR TITLE
Adding TaskState to be merged to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Jae Joon Han - GitHub Profile
 JoonsungPark - GitHub Profile
 Jenny Nguyen - GitHub Profile
 
-# TODO: Add detail for features, add instructions for how to use the program
+# TODO: Add detail for features, add instructions for how to use the program, link everyone's github to the file 

--- a/src/interface_adapter/task/TaskState.java
+++ b/src/interface_adapter/task/TaskState.java
@@ -1,0 +1,4 @@
+package interface_adapter.task;
+
+public class TaskState {
+}

--- a/src/interface_adapter/task/TaskState.java
+++ b/src/interface_adapter/task/TaskState.java
@@ -1,4 +1,26 @@
 package interface_adapter.task;
 
+/**
+ * The TaskState class is observed in TaskViewModel class.
+ */
 public class TaskState {
+    private String useCase = null;
+
+    /**
+     * Getter method for the use case.
+     *
+     * @return The use case of the state.
+     */
+    public String getUseCase() {
+        return useCase;
+    }
+
+    /**
+     * Setter method for the use case.
+     *
+     * @param useCase The use case of the state.
+     */
+    public void setUseCase(String useCase) {
+        this.useCase = useCase;
+    }
 }


### PR DESCRIPTION
This pull request introduces a new Java class named TaskState within the src/interface_adapter/task/ directory. The class includes a private member variable useCase with its corresponding getter and setter methods. Additionally, there is a brief Javadoc comment at the beginning of the class explaining that TaskState is observed in the TaskViewModel class.