### PR TITLE
Updated FileEventUserDataAccessObject.writeMaps and Added a Helper Function

### DIFF
--- a/src/data_access/FileEventUserDataAccessObject.java
+++ b/src/data_access/FileEventUserDataAccessObject.java
@@ -35,6 +35,7 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
 
     /**
      * This function makes an empty CSV file for a user in case they don't have one.
+     *
      * @param username The username of the user.
      */
     private void makeCsvFile(String username) {
@@ -62,7 +63,7 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
      * @param username The username of the user.
      */
     public void writeMaps(String username) {
-        String csvFilePath = filePath + username + ".csv";
+        String csvFilePath = filePath + File.separator + username + ".csv";
 
         int lineNumber = 1;
 
@@ -96,16 +97,24 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
                             title, description, location);
 
                     // UPDATE EVENTS
-                    // Check if the key (startDate) exists
-                    if (events.containsKey(startDate)) {
-                        // Get the ArrayList of events and add event to it
-                        ArrayList<Event> existingList = events.get(startDate);
-                        existingList.add(event);
-                    } else {
-                        // If the key doesn't exist, create a new ArrayList<Event>
-                        ArrayList<Event> newList = new ArrayList<>();
-                        newList.add(event);
-                        events.put(startDate, newList);
+                    // find the days that the event happens on
+                    ArrayList<LocalDate> eventDays = getDatesBetween(event.getStartDate(), event.getEndDate());
+
+                    // iterate through the days and put them in the corresponding arraylists in events
+                    for (LocalDate date : eventDays) {
+
+                        // check if the key (date) is in events already
+                        if (events.containsKey(date)) {
+                            // Get the ArrayList of events and add event to it
+                            ArrayList<Event> existingList = events.get(date);
+                            existingList.add(event);
+
+                        } else {
+                            // If the key doesn't exist, create a new ArrayList<Event>
+                            ArrayList<Event> newList = new ArrayList<>();
+                            newList.add(event);
+                            events.put(date, newList);
+                        }
                     }
 
                     //UPDATE EVENT REFERENCE
@@ -118,6 +127,22 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private ArrayList<LocalDate> getDatesBetween(LocalDate startDate, LocalDate endDate) {
+        ArrayList<LocalDate> datesInRange = new ArrayList<>();
+
+        // find how many days are in between startDate and endDate
+        long daysBetween = java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate);
+
+        for (int i = 0; i <= daysBetween; i++) {
+            // add "i" days to the start day until i equals the number of days in between
+            // startDate and endDate (which would make startDate.plusDays(i) = endDate
+            LocalDate date = startDate.plusDays(i);
+            datesInRange.add(date);
+        }
+
+        return datesInRange;
     }
 
 

--- a/src/data_access/FileEventUserDataAccessObject.java
+++ b/src/data_access/FileEventUserDataAccessObject.java
@@ -9,11 +9,12 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class FileEventUserDataAccessObject implements EventDataAccessInterface {
     private final String filePath;
-    private final Map<LocalDate, ArrayList<Event>> events;
+    private final Map<LocalDate, List<Event>> events;
     private final Map<Event, Integer> eventReference;
     private final EventFactory eventFactory;
 
@@ -24,7 +25,7 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
      * @param eventReference A reference to find the user's events
      * @param eventFactory   A class used to create an event
      */
-    public FileEventUserDataAccessObject(Map<LocalDate, ArrayList<Event>> events,
+    public FileEventUserDataAccessObject(Map<LocalDate, List<Event>> events,
                                          Map<Event, Integer> eventReference,
                                          EventFactory eventFactory) {
         this.filePath = "EventDirectory";
@@ -102,7 +103,7 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
 
                     // UPDATE EVENTS
                     // find the days that the event happens on
-                    ArrayList<LocalDate> eventDays = getDatesBetween(event.getStartDate(), event.getEndDate());
+                    List<LocalDate> eventDays = getDatesBetween(event.getStartDate(), event.getEndDate());
 
                     // iterate through the days and put them in the corresponding arraylists in events
                     for (LocalDate date : eventDays) {
@@ -110,12 +111,12 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
                         // check if the key (date) is in events already
                         if (events.containsKey(date)) {
                             // Get the ArrayList of events and add event to it
-                            ArrayList<Event> existingList = events.get(date);
+                            List<Event> existingList = events.get(date);
                             existingList.add(event);
 
                         } else {
                             // If the key doesn't exist, create a new ArrayList<Event>
-                            ArrayList<Event> newList = new ArrayList<>();
+                            List<Event> newList = new ArrayList<>();
                             newList.add(event);
                             events.put(date, newList);
                         }
@@ -141,8 +142,8 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
      * @param endDate   The ending date
      * @return An array list of the date(s) between startDate and endDate.
      */
-    private ArrayList<LocalDate> getDatesBetween(LocalDate startDate, LocalDate endDate) {
-        ArrayList<LocalDate> datesInRange = new ArrayList<>();
+    private List<LocalDate> getDatesBetween(LocalDate startDate, LocalDate endDate) {
+        List<LocalDate> datesInRange = new ArrayList<>();
 
         // find how many days are in between startDate and endDate
         long daysBetween = java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate);

--- a/src/data_access/FileEventUserDataAccessObject.java
+++ b/src/data_access/FileEventUserDataAccessObject.java
@@ -57,8 +57,12 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
     }
 
     /**
-     * This function finds the file for the given username in the EventDirectory and then
-     * updates the hash maps to reflect the information.
+     * This method takes the given username and finds the CSV file associated with the username
+     * (or calls makeCSVFile if the file does not exist). Then, it reads through the file and
+     * updates the two hash maps accordingly (i.e., having "events" have its keys be the startDate
+     * of the event, and the values being an ArrayList of Events that have that startDate. And having
+     * "eventReference" have its keys be the events with the corresponding values being the line
+     * that they can be found on in the CSV file).
      *
      * @param username The username of the user.
      */
@@ -129,6 +133,14 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
         }
     }
 
+    /**
+     * This method takes a startDate and an endDate and finds the dates from the startDate
+     * to the endDate, inclusive.
+     *
+     * @param startDate The starting date
+     * @param endDate   The ending date
+     * @return An array list of the date(s) between startDate and endDate.
+     */
     private ArrayList<LocalDate> getDatesBetween(LocalDate startDate, LocalDate endDate) {
         ArrayList<LocalDate> datesInRange = new ArrayList<>();
 


### PR DESCRIPTION
If an event happens on multiple days, the method will now store the event in all of the ArrayLists in "events" whose keys are the **dates that the event happens on**, rather than before when it would only store the event according to its startDate.

I implemented a helper function to help me, called `getDatesBetween`.

`getDatesBetween` : This method takes two LocalDate objects and returns an ArrayList of all of the days from the earlier date to the later date, inclusive. 
If the startDate and endDate are the same, then the ArrayList contains only one item, which is the one day that the event happens on.