### PR TITLE
50 changing how the event hash map stores events

### DIFF
--- a/src/data_access/FileEventUserDataAccessObject.java
+++ b/src/data_access/FileEventUserDataAccessObject.java
@@ -161,11 +161,14 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
 
     /**
      * This function is used when a user logs out. This clears the current hash maps so it
-     * won't contain the information of that user's events anymore.
+     * won't contain the information of that user's events anymore. It also clears the
+     * username attribute.
      */
     public void clearMaps() {
         events.clear();
         eventReference.clear();
+
+        this.username = null;
     }
 
 


### PR DESCRIPTION
I added a line to the `clearMaps` method. Now when the method is called it also clears the username attribute of the FileEventDataAccessObject class.

The events attribute now stores Lists instead of ArrayLists for versatility.