### PR TITLE
Fixed a Bug in the FileEventUserDataAccessObject and Added Getter Methods

### DIFF
--- a/Test/FileEventUserDataAccessObjectTest.java
+++ b/Test/FileEventUserDataAccessObjectTest.java
@@ -1,0 +1,78 @@
+import data_access.FileEventUserDataAccessObject;
+import entity.Event;
+import entity.EventFactory;
+import org.junit.Before;
+import org.junit.Test;
+import use_case.event.EventDataAccessInterface;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class FileEventUserDataAccessObjectTest {
+
+    private EventDataAccessInterface dataAccessObject;
+
+    @Before
+    public void setUp() {
+        // Create mock data for testing
+        Map<LocalDate, List<Event>> events = new HashMap<>();
+        Map<Event, Long> eventReference = new HashMap<>();
+        EventFactory eventFactory = new EventFactory();
+        dataAccessObject = new FileEventUserDataAccessObject(events, eventReference, eventFactory);
+    }
+
+    @Test
+    public void testWriteMapsUpdatesAttributesForUsername() {
+        // Make a simple CSV file
+        String csvData = "startDate, startTime, endDate, endTime, title, location, description\n" +
+                "2023-11-25,01:00,2023-11-26,02:30,title,location,description";
+
+        // The assigned username to the file
+        String username = "username";
+
+        // Set up the CSV file
+        String filePath = "DATA" + File.separator + "EventDirectory" + File.separator + username + ".csv";
+        createFileWithContent(filePath, csvData);
+
+        // Call writeMaps method
+        dataAccessObject.writeMaps(username);
+
+        // Check if the attributes are updated correctly
+        Map<LocalDate, List<Event>> events = ((FileEventUserDataAccessObject) dataAccessObject).getEvents();
+        Map<Event, Long> eventReference = ((FileEventUserDataAccessObject) dataAccessObject).getEventReference();
+
+        // See that there are two dates associated to the event in events, and only one reference number
+        // associated with the event in eventsReference
+        assertEquals(2, events.size());
+        assertEquals(1, eventReference.size());
+
+        // Clean up: delete the temporary file
+        deleteFile(filePath);
+    }
+
+    private void createFileWithContent(String filePath, String content) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
+            writer.write(content);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void deleteFile(String filePath) {
+    File file = new File(filePath);
+    if (file.exists()) {
+        file.delete();
+    }
+    }
+}

--- a/src/data_access/FileEventUserDataAccessObject.java
+++ b/src/data_access/FileEventUserDataAccessObject.java
@@ -58,10 +58,18 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
         }
     }
 
+    /**
+     * Gets the events
+     * @return  the events attribute.
+     */
     public Map<LocalDate, List<Event>> getEvents(){
         return events;
     }
 
+    /**
+     * Gets the eventReference
+     * @return  the eventsReference attribute.
+     */
     public Map<Event, Long> getEventReference() {
         return eventReference;
     }

--- a/src/data_access/FileEventUserDataAccessObject.java
+++ b/src/data_access/FileEventUserDataAccessObject.java
@@ -58,6 +58,14 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
         }
     }
 
+    public Map<LocalDate, List<Event>> getEvents(){
+        return events;
+    }
+
+    public Map<Event, Long> getEventReference() {
+        return eventReference;
+    }
+
     /**
      * This method takes the given username and finds the CSV file associated with the username
      * (or calls makeCSVFile if the file does not exist). Then, it reads through the file and
@@ -236,7 +244,7 @@ public class FileEventUserDataAccessObject implements EventDataAccessInterface {
                              String title, String location, String description) {
         String directoryPath = this.filePath + File.separator + this.username + ".csv";
 
-        String newLine = String.join(", ", startDate, startTime, endDate, endTime,
+        String newLine = String.join(",", startDate, startTime, endDate, endTime,
                 title, location, description);
 
         long lineCount;


### PR DESCRIPTION
In this pull request, I...

1. **Tested `FileEventUserDataAccessObject` using the `FileEventUserDataAccessObjectTest` class**. In this class, I **implemented a test called `testWriteMapsUpdatesAttributesForUsername`**, which creates an example CSV file called _username.csv_ and calls `writeMaps` on it to see if the attributes `events` and `eventReference` are updated correctly. More information about the specific test is found in the notes that I left. With this test, I noticed that there was an error in `writeMaps`.

2. **Debugged `writeMaps` and `saveEvent`**. I noticed that I would add an event in the CSV file with ", " in between each attribute. However, there should not be a space, and it should simply be a comma (i.e., ","). This is because **the `writeMaps` method would raise an error when trying to format a LocalDate string** since it wasn't in "yyyy-MM-dd" format but instead " yyyy-MM-dd". So in `saveEvent` I **changed it so it would save the event data without putting a space in between each attribute, and instead only a comma**.

3. **Added Getter Methods for `event` and `eventReference`**. This was to help test that the attributes were successfully/correctly updated.